### PR TITLE
fix: private servers are not playable anymore (1.41#500)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -161,7 +161,10 @@ function createWindow(): void {
 
   ipcMain.on(
     'patch-game-client',
-    async (event, args: { basePath: string; gameVersion: number }) => {
+    async (
+      event,
+      args: { basePath: string; gameVersion: number; serverType: 'public' | 'private' }
+    ) => {
       event.returnValue = undefined
 
       const gameDirPath = path.join(
@@ -199,7 +202,8 @@ function createWindow(): void {
           name: 'Auth Provider',
           startAddress: 0x4f97230,
           endAddress: 0x4f97233,
-          replacement: () => Buffer.from([0x78, 0x79, 0x7a])
+          replacement: () =>
+            Buffer.from(args.serverType === 'private' ? [0x64, 0x65, 0x76] : [0x78, 0x79, 0x7a])
         }
       ]
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -118,7 +118,8 @@ window.addEventListener('DOMContentLoaded', () => {
 
       ipcRenderer.sendSync('patch-game-client', {
         basePath: localStorage.getItem('gameDirectory'),
-        gameVersion: localStorage.getItem('gameVersion')
+        gameVersion: localStorage.getItem('gameVersion'),
+        serverType: localStorage.getItem('currServerType') || 'private'
       })
     })
   }

--- a/src/renderer/src/components/LaunchSection.tsx
+++ b/src/renderer/src/components/LaunchSection.tsx
@@ -87,7 +87,10 @@ function LaunchSection(): JSX.Element {
 
                     setPopUpState(false)
                     return window.launchGame({ setGameState, authkey })
-                  } else return window.launchGame({ setGameState })
+                  } else {
+                    setPopUpState(false)
+                    return window.launchGame({ setGameState })
+                  }
                 }}
               />
             )


### PR DESCRIPTION
When trying to join a server via the "private" tab the user receives a `1.41#500` error. This is because the Auth Provider has been changed to `xyz` from `dev`.

The fix now patches the AuthProvider to `xyz` when its a public server and `dev` when its a private one.